### PR TITLE
Update regex use for extracting icon's name from CSS file

### DIFF
--- a/fields/iconmoon-base-field.php
+++ b/fields/iconmoon-base-field.php
@@ -63,7 +63,7 @@ class acf_field_iconmoon_base extends acf_field {
 		// If not extract them from the CSS file
 		$contents = file_get_contents( $filepath );
 
-		preg_match_all( '#.icon-(.*):before#', $contents, $css );
+		preg_match_all( '#\.icon-([^:]*)::?before#', $contents, $css );
 		array_shift( $css );
 
 


### PR DESCRIPTION
Handle case where pseudo selector use double colon "::".